### PR TITLE
teams from regular

### DIFF
--- a/client/src/pages/GameDetailPage.tsx
+++ b/client/src/pages/GameDetailPage.tsx
@@ -32,6 +32,7 @@ export function GameDetailPage() {
   const [loading, setLoading] = useState(true);
   const [openScoreDialog, setOpenScoreDialog] = useState(false);
   const [scores, setScores] = useState({ team1: 0, team2: 0 });
+  const [actionAlert, setActionAlert] = useState<{ severity: 'info' | 'warning' | 'error'; message: string } | null>(null);
   const { id } = useParams<{ id: string }>();
   const { user } = useAuth();
   const navigate = useNavigate();
@@ -56,9 +57,32 @@ export function GameDetailPage() {
 
   const handleAttendance = async (playerId: number, status: 'present' | 'absent') => {
     try {
-      await attendanceApi.update(Number(id), playerId, status);
-      loadGame();
-    } catch (error) {
+      const response = await attendanceApi.update(Number(id), playerId, status);
+      const data = response.data;
+
+      if (status === 'absent') {
+        if (data.replacementSuggestions.length > 0) {
+          const names = data.replacementSuggestions.map((candidate) => candidate.name).join(', ');
+          setActionAlert({
+            severity: 'info',
+            message: `${data.replacementMessage || 'Suggested replacements'} ${names}`,
+          });
+        } else if (data.replacementMessage) {
+          setActionAlert({
+            severity: 'warning',
+            message: data.replacementMessage,
+          });
+        }
+      } else {
+        setActionAlert(null);
+      }
+
+      await loadGame();
+    } catch (error: any) {
+      setActionAlert({
+        severity: 'error',
+        message: error?.response?.data?.error || 'Failed to update attendance',
+      });
       console.error('Failed to update attendance:', error);
     }
   };
@@ -66,8 +90,13 @@ export function GameDetailPage() {
   const handleAutoBalance = async () => {
     try {
       await teamsApi.autoBalance(Number(id));
-      loadGame();
-    } catch (error) {
+      setActionAlert(null);
+      await loadGame();
+    } catch (error: any) {
+      setActionAlert({
+        severity: 'error',
+        message: error?.response?.data?.error || 'Failed to auto-balance teams',
+      });
       console.error('Failed to auto-balance teams:', error);
     }
   };
@@ -150,16 +179,17 @@ export function GameDetailPage() {
           )}
         </Paper>
 
+        {actionAlert && (
+          <Alert severity={actionAlert.severity} sx={{ mb: 3 }}>
+            {actionAlert.message}
+          </Alert>
+        )}
+
         <Grid container spacing={3}>
           <Grid item xs={12} md={6}>
             <Paper sx={{ p: 3 }}>
               <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
                 <Typography variant="h5">Attendance</Typography>
-                {user?.isAdmin && presentPlayers.length >= 4 && (
-                  <Button variant="outlined" size="small" onClick={handleAutoBalance}>
-                    Auto-Balance Teams
-                  </Button>
-                )}
               </Box>
 
               <Typography variant="subtitle2" color="text.secondary" gutterBottom>
@@ -254,13 +284,18 @@ export function GameDetailPage() {
 
           <Grid item xs={12} md={6}>
             <Paper sx={{ p: 3 }}>
-              <Typography variant="h5" gutterBottom>
-                Teams
-              </Typography>
+              <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+                <Typography variant="h5">Teams</Typography>
+                {user?.isAdmin && (
+                  <Button variant="outlined" size="small" onClick={handleAutoBalance}>
+                    Create Teams From Regulars
+                  </Button>
+                )}
+              </Box>
 
               {team1.length === 0 && team2.length === 0 ? (
                 <Alert severity="info">
-                  Teams not created yet. Confirm attendance first.
+                  Teams not created yet. Use "Create Teams From Regulars" to plan teams before attendance is confirmed.
                 </Alert>
               ) : (
                 <Grid container spacing={2}>

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { AttendanceUpdateResponse } from '../types';
 
 const API_BASE_URL = '/api';
 
@@ -44,7 +45,7 @@ export const gamesApi = {
 // Attendance API
 export const attendanceApi = {
   update: (gameId: number, playerId: number, status: 'present' | 'absent') =>
-    api.put(`/attendance/${gameId}/${playerId}`, { status }),
+    api.put<AttendanceUpdateResponse>(`/attendance/${gameId}/${playerId}`, { status }),
 };
 
 // Teams API

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -43,6 +43,19 @@ export interface Attendance {
   is_regular?: number;
 }
 
+export interface ReplacementSuggestion {
+  playerId: number;
+  name: string;
+  isRegular: boolean;
+  score: number;
+}
+
+export interface AttendanceUpdateResponse {
+  attendance: Attendance;
+  replacementSuggestions: ReplacementSuggestion[];
+  replacementMessage?: string;
+}
+
 export interface Team {
   team_number: number;
   player_id: number;

--- a/server/src/routes/attendance.ts
+++ b/server/src/routes/attendance.ts
@@ -1,9 +1,33 @@
 import express, { Request, Response } from 'express';
-import { getAsync, runAsync } from '../database.js';
+import { allAsync, getAsync, runAsync } from '../database.js';
 import { Attendance } from '../types.js';
 import { authenticateToken, AuthRequest } from '../middleware/auth.js';
 
 const router = express.Router();
+
+interface ReplacementCandidate {
+  player_id: number;
+  name: string;
+  position: 'forward' | 'defense' | 'goalie';
+  is_regular: number;
+  forward_rating: number;
+  defense_rating: number;
+  goalie_rating: number;
+  offense_weight: number;
+  defense_weight: number;
+}
+
+function replacementScore(player: ReplacementCandidate): number {
+  if (player.position === 'goalie') {
+    return player.goalie_rating;
+  }
+
+  if (player.position === 'defense') {
+    return player.defense_rating * 2 + player.defense_weight;
+  }
+
+  return player.forward_rating * 2 + player.offense_weight;
+}
 
 // Update attendance status
 router.put('/:gameId/:playerId', authenticateToken, async (req: AuthRequest, res: Response) => {
@@ -66,7 +90,103 @@ router.put('/:gameId/:playerId', authenticateToken, async (req: AuthRequest, res
       [gameId, playerId]
     ) as Attendance;
 
-    res.json(attendance);
+    let replacementSuggestions: Array<{
+      playerId: number;
+      name: string;
+      isRegular: boolean;
+      score: number;
+    }> = [];
+    let replacementMessage: string | undefined;
+
+    if (status === 'absent') {
+      const teamAssignment = await getAsync(
+        'SELECT team_number FROM teams WHERE game_id = ? AND player_id = ?',
+        [gameId, playerId]
+      ) as { team_number: number } | undefined;
+
+      if (teamAssignment) {
+        const absentPlayer = await getAsync(
+          `SELECT
+            id as player_id,
+            name,
+            position,
+            is_regular,
+            forward_rating,
+            defense_rating,
+            goalie_rating,
+            offense_weight,
+            defense_weight
+          FROM players
+          WHERE id = ? AND league_id = ?`,
+          [playerId, req.leagueId]
+        ) as ReplacementCandidate | undefined;
+
+        if (absentPlayer) {
+          const absentScore = replacementScore(absentPlayer);
+
+          const candidates = await allAsync(
+            `SELECT
+              p.id as player_id,
+              p.name,
+              p.position,
+              p.is_regular,
+              p.forward_rating,
+              p.defense_rating,
+              p.goalie_rating,
+              p.offense_weight,
+              p.defense_weight
+            FROM players p
+            LEFT JOIN attendance a ON a.player_id = p.id AND a.game_id = ?
+            LEFT JOIN teams t ON t.player_id = p.id AND t.game_id = ?
+            WHERE p.league_id = ?
+              AND p.is_active = 1
+              AND p.position = ?
+              AND p.id != ?
+              AND t.player_id IS NULL
+              AND (a.status IS NULL OR a.status != 'absent')`,
+            [gameId, gameId, req.leagueId, absentPlayer.position, playerId]
+          ) as ReplacementCandidate[];
+
+          const scoredCandidates = candidates
+            .map((candidate) => ({
+              ...candidate,
+              score: replacementScore(candidate),
+            }))
+            .sort((a, b) => {
+              const aDiff = Math.abs(a.score - absentScore);
+              const bDiff = Math.abs(b.score - absentScore);
+              if (aDiff === bDiff) {
+                return b.score - a.score;
+              }
+              return aDiff - bDiff;
+            });
+
+          const similarlyRatedOrBetter = scoredCandidates.filter((candidate) => candidate.score >= absentScore);
+          const selected = similarlyRatedOrBetter.slice(0, 3);
+
+          replacementSuggestions = selected.map((candidate) => ({
+            playerId: candidate.player_id,
+            name: candidate.name,
+            isRegular: candidate.is_regular === 1,
+            score: candidate.score,
+          }));
+
+          if (replacementSuggestions.length > 0) {
+            replacementMessage = `Team ${teamAssignment.team_number}: contact a replacement for ${absentPlayer.name}.`;
+          } else if (scoredCandidates.length > 0) {
+            replacementMessage = `No similarly rated or better ${absentPlayer.position} available for ${absentPlayer.name}.`;
+          } else {
+            replacementMessage = `No available ${absentPlayer.position} replacements found for ${absentPlayer.name}.`;
+          }
+        }
+      }
+    }
+
+    res.json({
+      attendance,
+      replacementSuggestions,
+      replacementMessage,
+    });
   } catch (error) {
     console.error('Update attendance error:', error);
     res.status(500).json({ error: 'Internal server error' });

--- a/server/src/routes/teams.ts
+++ b/server/src/routes/teams.ts
@@ -266,16 +266,15 @@ router.post('/:gameId/auto-balance', authenticateToken, requireAdmin, async (req
       return res.status(404).json({ error: 'Game not found' });
     }
 
-    // Get all players who are present
+    // Build planning teams from active regulars, independent of attendance confirmations.
     const presentPlayers = await allAsync(`
       SELECT p.id, p.name, p.position, p.offense_weight, p.defense_weight, p.defense_rating, p.forward_rating, p.goalie_rating
       FROM players p
-      JOIN attendance a ON p.id = a.player_id
-      WHERE a.game_id = ? AND a.status = 'present' AND p.league_id = ?
-    `, [gameId, req.leagueId]) as RatedPlayer[];
+      WHERE p.league_id = ? AND p.is_active = 1 AND p.is_regular = 1
+    `, [req.leagueId]) as RatedPlayer[];
 
     if (presentPlayers.length < 2) {
-      return res.status(400).json({ error: 'Not enough players confirmed' });
+      return res.status(400).json({ error: 'Not enough regular players available' });
     }
 
     const skaters = presentPlayers.filter((p) => p.position !== 'goalie');


### PR DESCRIPTION
What I changed
Team auto-balance now uses active regular players only, regardless of attendance status:

[teams.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
It no longer depends on present confirmations.
It plans from the regular roster ([is_regular = 1](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), [is_active = 1](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) in that league.
UI now clearly exposes this flow:

[GameDetailPage.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Moved action to the Teams card and renamed button to:
Create Teams From Regulars
Updated empty-state message to explicitly say this is for pre-attendance planning.
Result
You can open a game and click Create Teams From Regulars immediately.
Attendance can be confirmed later.
If someone later marks absent, your replacement suggestion logic still runs.