### PR TITLE
i18n

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,11 @@
+# Copilot Instructions
+
+## Language Requirements
+- Always support both English (`en`) and French (`fr`) for any user-facing text.
+- When adding or changing UI labels, buttons, dialogs, alerts, helper text, or page titles, update both language translations.
+- Do not hardcode new visible strings directly in components when a translation key can be used.
+- If a new feature introduces new copy, add translation keys for both languages in the i18n layer.
+
+## Consistency
+- Keep translation key naming consistent and grouped by page/feature.
+- Prefer simple, neutral wording that translates clearly between English and French.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { AuthProvider } from './contexts/AuthContext';
+import { I18nProvider } from './contexts/I18nContext';
 import { PrivateRoute } from './components/PrivateRoute';
 import { LoginPage } from './pages/LoginPage';
 import { GamesPage } from './pages/GamesPage';
@@ -13,38 +14,40 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <AuthProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/login" element={<LoginPage />} />
-            <Route
-              path="/"
-              element={
-                <PrivateRoute>
-                  <GamesPage />
-                </PrivateRoute>
-              }
-            />
-            <Route
-              path="/games/:id"
-              element={
-                <PrivateRoute>
-                  <GameDetailPage />
-                </PrivateRoute>
-              }
-            />
-            <Route
-              path="/players"
-              element={
-                <PrivateRoute>
-                  <PlayersPage />
-                </PrivateRoute>
-              }
-            />
-            <Route path="*" element={<Navigate to="/" />} />
-          </Routes>
-        </BrowserRouter>
-      </AuthProvider>
+      <I18nProvider>
+        <AuthProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/login" element={<LoginPage />} />
+              <Route
+                path="/"
+                element={
+                  <PrivateRoute>
+                    <GamesPage />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/games/:id"
+                element={
+                  <PrivateRoute>
+                    <GameDetailPage />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/players"
+                element={
+                  <PrivateRoute>
+                    <PlayersPage />
+                  </PrivateRoute>
+                }
+              />
+              <Route path="*" element={<Navigate to="/" />} />
+            </Routes>
+          </BrowserRouter>
+        </AuthProvider>
+      </I18nProvider>
     </ThemeProvider>
   );
 }

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -1,11 +1,13 @@
-import { AppBar, Toolbar, Typography, Button, Box } from '@mui/material';
+import { AppBar, Toolbar, Typography, Button, Box, FormControl, Select, MenuItem } from '@mui/material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { useI18n } from '../contexts/I18nContext';
 import SportsHockeyIcon from '@mui/icons-material/SportsHockey';
 import LogoutIcon from '@mui/icons-material/Logout';
 
 export function Navigation() {
   const { user, logout } = useAuth();
+  const { language, setLanguage, t } = useI18n();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -15,8 +17,8 @@ export function Navigation() {
   };
 
   const navItems = [
-    { label: 'Games', path: '/' },
-    { label: 'Players', path: '/players' },
+    { label: t('nav.games'), path: '/' },
+    { label: t('nav.players'), path: '/players' },
   ];
 
   if (!user) return null;
@@ -26,7 +28,7 @@ export function Navigation() {
       <Toolbar>
         <SportsHockeyIcon sx={{ mr: 2 }} />
         <Typography variant="h6" component="div" sx={{ flexGrow: 0, mr: 4 }}>
-          Hockey League
+          {t('nav.leagueName')}
         </Typography>
         
         <Box sx={{ flexGrow: 1, display: 'flex', gap: 2 }}>
@@ -45,11 +47,22 @@ export function Navigation() {
         </Box>
 
         <Typography variant="body2" sx={{ mr: 2 }}>
-          {user.username} {user.isAdmin && '(Admin)'}
+          {user.username} {user.isAdmin && `(${t('nav.admin')})`}
         </Typography>
+
+        <FormControl size="small" sx={{ mr: 2, minWidth: 120 }}>
+          <Select
+            value={language}
+            onChange={(event) => setLanguage(event.target.value as 'en' | 'fr')}
+            sx={{ color: 'white', '.MuiSvgIcon-root': { color: 'white' }, '& .MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.4)' } }}
+          >
+            <MenuItem value="en">{t('lang.english')}</MenuItem>
+            <MenuItem value="fr">{t('lang.french')}</MenuItem>
+          </Select>
+        </FormControl>
         
         <Button color="inherit" onClick={handleLogout} startIcon={<LogoutIcon />}>
-          Logout
+          {t('nav.logout')}
         </Button>
       </Toolbar>
     </AppBar>

--- a/client/src/contexts/I18nContext.tsx
+++ b/client/src/contexts/I18nContext.tsx
@@ -1,0 +1,287 @@
+import { createContext, useContext, useEffect, useMemo, useState, ReactNode } from 'react';
+
+export type Language = 'en' | 'fr';
+
+type TranslationKey =
+  | 'nav.games'
+  | 'nav.players'
+  | 'nav.logout'
+  | 'nav.admin'
+  | 'nav.leagueName'
+  | 'lang.english'
+  | 'lang.french'
+  | 'login.title'
+  | 'login.username'
+  | 'login.password'
+  | 'login.submit'
+  | 'login.failed'
+  | 'login.defaultAdmin'
+  | 'games.title'
+  | 'games.newGame'
+  | 'games.time'
+  | 'games.location'
+  | 'games.score'
+  | 'games.none'
+  | 'games.createTitle'
+  | 'games.date'
+  | 'games.cancel'
+  | 'games.create'
+  | 'games.status.scheduled'
+  | 'games.status.completed'
+  | 'games.status.cancelled'
+  | 'players.title'
+  | 'players.add'
+  | 'players.name'
+  | 'players.email'
+  | 'players.phone'
+  | 'players.type'
+  | 'players.position'
+  | 'players.offenseWeight'
+  | 'players.defenseWeight'
+  | 'players.defenseRating'
+  | 'players.forwardRating'
+  | 'players.goalieRating'
+  | 'players.actions'
+  | 'players.regular'
+  | 'players.sub'
+  | 'players.addTitle'
+  | 'players.updateTitle'
+  | 'players.regularToggle'
+  | 'players.forward'
+  | 'players.defense'
+  | 'players.goalie'
+  | 'players.cancel'
+  | 'players.save'
+  | 'players.addPlayer'
+  | 'gameDetail.back'
+  | 'gameDetail.titlePrefix'
+  | 'gameDetail.time'
+  | 'gameDetail.location'
+  | 'gameDetail.finalScore'
+  | 'gameDetail.recordScore'
+  | 'gameDetail.attendance'
+  | 'gameDetail.present'
+  | 'gameDetail.pending'
+  | 'gameDetail.absent'
+  | 'gameDetail.markAbsent'
+  | 'gameDetail.markPresent'
+  | 'gameDetail.teams'
+  | 'gameDetail.createTeamsFromRegulars'
+  | 'gameDetail.teamsEmpty'
+  | 'gameDetail.team1'
+  | 'gameDetail.team2'
+  | 'gameDetail.scoreDialog'
+  | 'gameDetail.team1Score'
+  | 'gameDetail.team2Score'
+  | 'gameDetail.saveScore'
+  | 'gameDetail.gameNotFound'
+  | 'gameDetail.failedAttendance'
+  | 'gameDetail.failedAutoBalance'
+  | 'gameDetail.attendance.present'
+  | 'gameDetail.attendance.absent'
+  | 'gameDetail.attendance.pending';
+
+const translations: Record<Language, Record<TranslationKey, string>> = {
+  en: {
+    'nav.games': 'Games',
+    'nav.players': 'Players',
+    'nav.logout': 'Logout',
+    'nav.admin': 'Admin',
+    'nav.leagueName': 'Hockey League',
+    'lang.english': 'English',
+    'lang.french': 'French',
+    'login.title': 'Hockey League',
+    'login.username': 'Username',
+    'login.password': 'Password',
+    'login.submit': 'Login',
+    'login.failed': 'Login failed',
+    'login.defaultAdmin': 'Default admin: username: admin, password: admin123',
+    'games.title': 'Games',
+    'games.newGame': 'New Game',
+    'games.time': 'Time',
+    'games.location': 'Location',
+    'games.score': 'Score',
+    'games.none': 'No games scheduled yet',
+    'games.createTitle': 'Create New Game',
+    'games.date': 'Date',
+    'games.cancel': 'Cancel',
+    'games.create': 'Create',
+    'games.status.scheduled': 'scheduled',
+    'games.status.completed': 'completed',
+    'games.status.cancelled': 'cancelled',
+    'players.title': 'Players',
+    'players.add': 'Add Player',
+    'players.name': 'Name',
+    'players.email': 'Email',
+    'players.phone': 'Phone',
+    'players.type': 'Type',
+    'players.position': 'Position',
+    'players.offenseWeight': 'Offense Weight',
+    'players.defenseWeight': 'Defense Weight',
+    'players.defenseRating': 'Defense',
+    'players.forwardRating': 'Forward',
+    'players.goalieRating': 'Goalie',
+    'players.actions': 'Actions',
+    'players.regular': 'Regular',
+    'players.sub': 'Sub',
+    'players.addTitle': 'Add New Player',
+    'players.updateTitle': 'Update Player Ratings',
+    'players.regularToggle': 'Regular Player',
+    'players.forward': 'Forward',
+    'players.defense': 'Defense',
+    'players.goalie': 'Goalie',
+    'players.cancel': 'Cancel',
+    'players.save': 'Save Ratings',
+    'players.addPlayer': 'Add Player',
+    'gameDetail.back': 'Back to Games',
+    'gameDetail.titlePrefix': 'Game on',
+    'gameDetail.time': 'Time',
+    'gameDetail.location': 'Location',
+    'gameDetail.finalScore': 'Final Score',
+    'gameDetail.recordScore': 'Record Score',
+    'gameDetail.attendance': 'Attendance',
+    'gameDetail.present': 'Present',
+    'gameDetail.pending': 'Pending',
+    'gameDetail.absent': 'Absent',
+    'gameDetail.markAbsent': 'Mark Absent',
+    'gameDetail.markPresent': 'Mark Present',
+    'gameDetail.teams': 'Teams',
+    'gameDetail.createTeamsFromRegulars': 'Create Teams From Regulars',
+    'gameDetail.teamsEmpty': 'Teams not created yet. Use "Create Teams From Regulars" to plan teams before attendance is confirmed.',
+    'gameDetail.team1': 'Team 1',
+    'gameDetail.team2': 'Team 2',
+    'gameDetail.scoreDialog': 'Record Game Score',
+    'gameDetail.team1Score': 'Team 1 Score',
+    'gameDetail.team2Score': 'Team 2 Score',
+    'gameDetail.saveScore': 'Save Score',
+    'gameDetail.gameNotFound': 'Game not found',
+    'gameDetail.failedAttendance': 'Failed to update attendance',
+    'gameDetail.failedAutoBalance': 'Failed to auto-balance teams',
+    'gameDetail.attendance.present': 'present',
+    'gameDetail.attendance.absent': 'absent',
+    'gameDetail.attendance.pending': 'pending',
+  },
+  fr: {
+    'nav.games': 'Matchs',
+    'nav.players': 'Joueurs',
+    'nav.logout': 'Deconnexion',
+    'nav.admin': 'Admin',
+    'nav.leagueName': 'Ligue de hockey',
+    'lang.english': 'Anglais',
+    'lang.french': 'Francais',
+    'login.title': 'Ligue de hockey',
+    'login.username': 'Nom d\'utilisateur',
+    'login.password': 'Mot de passe',
+    'login.submit': 'Connexion',
+    'login.failed': 'Echec de connexion',
+    'login.defaultAdmin': 'Admin par defaut : nom d\'utilisateur : admin, mot de passe : admin123',
+    'games.title': 'Matchs',
+    'games.newGame': 'Nouveau match',
+    'games.time': 'Heure',
+    'games.location': 'Lieu',
+    'games.score': 'Score',
+    'games.none': 'Aucun match planifie',
+    'games.createTitle': 'Creer un nouveau match',
+    'games.date': 'Date',
+    'games.cancel': 'Annuler',
+    'games.create': 'Creer',
+    'games.status.scheduled': 'planifie',
+    'games.status.completed': 'termine',
+    'games.status.cancelled': 'annule',
+    'players.title': 'Joueurs',
+    'players.add': 'Ajouter un joueur',
+    'players.name': 'Nom',
+    'players.email': 'Courriel',
+    'players.phone': 'Telephone',
+    'players.type': 'Type',
+    'players.position': 'Position',
+    'players.offenseWeight': 'Poids offensive',
+    'players.defenseWeight': 'Poids defensive',
+    'players.defenseRating': 'Defense',
+    'players.forwardRating': 'Attaque',
+    'players.goalieRating': 'Gardien',
+    'players.actions': 'Actions',
+    'players.regular': 'Regulier',
+    'players.sub': 'Remplacant',
+    'players.addTitle': 'Ajouter un nouveau joueur',
+    'players.updateTitle': 'Mettre a jour les cotes du joueur',
+    'players.regularToggle': 'Joueur regulier',
+    'players.forward': 'Attaquant',
+    'players.defense': 'Defenseur',
+    'players.goalie': 'Gardien',
+    'players.cancel': 'Annuler',
+    'players.save': 'Enregistrer les cotes',
+    'players.addPlayer': 'Ajouter le joueur',
+    'gameDetail.back': 'Retour aux matchs',
+    'gameDetail.titlePrefix': 'Match du',
+    'gameDetail.time': 'Heure',
+    'gameDetail.location': 'Lieu',
+    'gameDetail.finalScore': 'Score final',
+    'gameDetail.recordScore': 'Enregistrer le score',
+    'gameDetail.attendance': 'Presence',
+    'gameDetail.present': 'Presents',
+    'gameDetail.pending': 'En attente',
+    'gameDetail.absent': 'Absents',
+    'gameDetail.markAbsent': 'Marquer absent',
+    'gameDetail.markPresent': 'Marquer present',
+    'gameDetail.teams': 'Equipes',
+    'gameDetail.createTeamsFromRegulars': 'Creer les equipes des reguliers',
+    'gameDetail.teamsEmpty': 'Aucune equipe creee. Utilisez "Creer les equipes des reguliers" pour planifier avant la confirmation de presence.',
+    'gameDetail.team1': 'Equipe 1',
+    'gameDetail.team2': 'Equipe 2',
+    'gameDetail.scoreDialog': 'Enregistrer le score du match',
+    'gameDetail.team1Score': 'Score equipe 1',
+    'gameDetail.team2Score': 'Score equipe 2',
+    'gameDetail.saveScore': 'Enregistrer le score',
+    'gameDetail.gameNotFound': 'Match introuvable',
+    'gameDetail.failedAttendance': 'Echec de mise a jour de la presence',
+    'gameDetail.failedAutoBalance': 'Echec de creation automatique des equipes',
+    'gameDetail.attendance.present': 'present',
+    'gameDetail.attendance.absent': 'absent',
+    'gameDetail.attendance.pending': 'en attente',
+  },
+};
+
+interface I18nContextType {
+  language: Language;
+  setLanguage: (language: Language) => void;
+  t: (key: TranslationKey) => string;
+}
+
+const I18nContext = createContext<I18nContextType | undefined>(undefined);
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguageState] = useState<Language>('en');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('language');
+    if (stored === 'en' || stored === 'fr') {
+      setLanguageState(stored);
+    }
+  }, []);
+
+  const setLanguage = (next: Language) => {
+    setLanguageState(next);
+    localStorage.setItem('language', next);
+  };
+
+  const value = useMemo(
+    () => ({
+      language,
+      setLanguage,
+      t: (key: TranslationKey) => translations[language][key],
+    }),
+    [language]
+  );
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  const context = useContext(I18nContext);
+  if (!context) {
+    throw new Error('useI18n must be used within an I18nProvider');
+  }
+
+  return context;
+}

--- a/client/src/pages/GameDetailPage.tsx
+++ b/client/src/pages/GameDetailPage.tsx
@@ -25,6 +25,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { gamesApi, attendanceApi, teamsApi } from '../services/api';
 import { GameWithDetails } from '../types';
+import { useI18n } from '../contexts/I18nContext';
 import { Navigation } from '../components/Navigation';
 
 export function GameDetailPage() {
@@ -35,6 +36,7 @@ export function GameDetailPage() {
   const [actionAlert, setActionAlert] = useState<{ severity: 'info' | 'warning' | 'error'; message: string } | null>(null);
   const { id } = useParams<{ id: string }>();
   const { user } = useAuth();
+  const { t } = useI18n();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -81,7 +83,7 @@ export function GameDetailPage() {
     } catch (error: any) {
       setActionAlert({
         severity: 'error',
-        message: error?.response?.data?.error || 'Failed to update attendance',
+        message: error?.response?.data?.error || t('gameDetail.failedAttendance'),
       });
       console.error('Failed to update attendance:', error);
     }
@@ -95,7 +97,7 @@ export function GameDetailPage() {
     } catch (error: any) {
       setActionAlert({
         severity: 'error',
-        message: error?.response?.data?.error || 'Failed to auto-balance teams',
+        message: error?.response?.data?.error || t('gameDetail.failedAutoBalance'),
       });
       console.error('Failed to auto-balance teams:', error);
     }
@@ -132,7 +134,7 @@ export function GameDetailPage() {
       <>
         <Navigation />
         <Container maxWidth="lg" sx={{ mt: 4 }}>
-          <Typography>Game not found</Typography>
+          <Typography>{t('gameDetail.gameNotFound')}</Typography>
         </Container>
       </>
     );
@@ -150,30 +152,33 @@ export function GameDetailPage() {
       <Navigation />
       <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
         <Button onClick={() => navigate('/')} sx={{ mb: 2 }}>
-          ← Back to Games
+          ← {t('gameDetail.back')}
         </Button>
 
         <Paper sx={{ p: 3, mb: 3 }}>
           <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
             <Typography variant="h4">
-              Game on {new Date(game.date).toLocaleDateString()}
+              {t('gameDetail.titlePrefix')} {new Date(game.date).toLocaleDateString()}
             </Typography>
-            <Chip label={game.status} color="primary" />
+            <Chip
+              label={t(`games.status.${game.status}` as 'games.status.scheduled' | 'games.status.completed' | 'games.status.cancelled')}
+              color="primary"
+            />
           </Box>
           
-          {game.time && <Typography>Time: {game.time}</Typography>}
-          {game.location && <Typography>Location: {game.location}</Typography>}
+          {game.time && <Typography>{t('gameDetail.time')}: {game.time}</Typography>}
+          {game.location && <Typography>{t('gameDetail.location')}: {game.location}</Typography>}
           
           {game.status === 'completed' && game.team1_score !== undefined && (
             <Typography variant="h5" sx={{ mt: 2 }}>
-              Final Score: {game.team1_score} - {game.team2_score}
+              {t('gameDetail.finalScore')}: {game.team1_score} - {game.team2_score}
             </Typography>
           )}
 
           {user?.isAdmin && game.status !== 'completed' && (
             <Box mt={2}>
               <Button variant="contained" onClick={() => setOpenScoreDialog(true)}>
-                Record Score
+                {t('gameDetail.recordScore')}
               </Button>
             </Box>
           )}
@@ -189,11 +194,11 @@ export function GameDetailPage() {
           <Grid item xs={12} md={6}>
             <Paper sx={{ p: 3 }}>
               <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-                <Typography variant="h5">Attendance</Typography>
+                <Typography variant="h5">{t('gameDetail.attendance')}</Typography>
               </Box>
 
               <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                Present ({presentPlayers.length})
+                {t('gameDetail.present')} ({presentPlayers.length})
               </Typography>
               <List dense>
                 {presentPlayers.map((att) => (
@@ -201,14 +206,14 @@ export function GameDetailPage() {
                     <CheckCircleIcon color="success" sx={{ mr: 1 }} />
                     <ListItemText
                       primary={att.player_name}
-                      secondary={att.is_regular ? 'Regular' : 'Sub'}
+                      secondary={att.is_regular ? t('players.regular') : t('players.sub')}
                     />
                     {user?.isAdmin && (
                       <Button
                         size="small"
                         onClick={() => handleAttendance(att.player_id, 'absent')}
                       >
-                        Mark Absent
+                        {t('gameDetail.markAbsent')}
                       </Button>
                     )}
                   </ListItem>
@@ -219,14 +224,14 @@ export function GameDetailPage() {
                 <>
                   <Divider sx={{ my: 2 }} />
                   <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                    Pending ({pendingPlayers.length})
+                    {t('gameDetail.pending')} ({pendingPlayers.length})
                   </Typography>
                   <List dense>
                     {pendingPlayers.map((att) => (
                       <ListItem key={att.id}>
                         <ListItemText
                           primary={att.player_name}
-                          secondary={att.is_regular ? 'Regular' : 'Sub'}
+                          secondary={att.is_regular ? t('players.regular') : t('players.sub')}
                         />
                         {user?.isAdmin && (
                           <Box>
@@ -235,14 +240,14 @@ export function GameDetailPage() {
                               color="success"
                               onClick={() => handleAttendance(att.player_id, 'present')}
                             >
-                              Present
+                              {t('gameDetail.present')}
                             </Button>
                             <Button
                               size="small"
                               color="error"
                               onClick={() => handleAttendance(att.player_id, 'absent')}
                             >
-                              Absent
+                              {t('gameDetail.absent')}
                             </Button>
                           </Box>
                         )}
@@ -256,7 +261,7 @@ export function GameDetailPage() {
                 <>
                   <Divider sx={{ my: 2 }} />
                   <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                    Absent ({absentPlayers.length})
+                    {t('gameDetail.absent')} ({absentPlayers.length})
                   </Typography>
                   <List dense>
                     {absentPlayers.map((att) => (
@@ -264,14 +269,14 @@ export function GameDetailPage() {
                         <CancelIcon color="error" sx={{ mr: 1 }} />
                         <ListItemText
                           primary={att.player_name}
-                          secondary={att.is_regular ? 'Regular' : 'Sub'}
+                          secondary={att.is_regular ? t('players.regular') : t('players.sub')}
                         />
                         {user?.isAdmin && (
                           <Button
                             size="small"
                             onClick={() => handleAttendance(att.player_id, 'present')}
                           >
-                            Mark Present
+                            {t('gameDetail.markPresent')}
                           </Button>
                         )}
                       </ListItem>
@@ -285,23 +290,23 @@ export function GameDetailPage() {
           <Grid item xs={12} md={6}>
             <Paper sx={{ p: 3 }}>
               <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-                <Typography variant="h5">Teams</Typography>
+                <Typography variant="h5">{t('gameDetail.teams')}</Typography>
                 {user?.isAdmin && (
                   <Button variant="outlined" size="small" onClick={handleAutoBalance}>
-                    Create Teams From Regulars
+                    {t('gameDetail.createTeamsFromRegulars')}
                   </Button>
                 )}
               </Box>
 
               {team1.length === 0 && team2.length === 0 ? (
                 <Alert severity="info">
-                  Teams not created yet. Use "Create Teams From Regulars" to plan teams before attendance is confirmed.
+                  {t('gameDetail.teamsEmpty')}
                 </Alert>
               ) : (
                 <Grid container spacing={2}>
                   <Grid item xs={6}>
                     <Typography variant="h6" color="primary">
-                      Team 1
+                      {t('gameDetail.team1')}
                     </Typography>
                     <List dense>
                       {team1.map((player) => (
@@ -313,7 +318,7 @@ export function GameDetailPage() {
                   </Grid>
                   <Grid item xs={6}>
                     <Typography variant="h6" color="secondary">
-                      Team 2
+                      {t('gameDetail.team2')}
                     </Typography>
                     <List dense>
                       {team2.map((player) => (
@@ -330,18 +335,18 @@ export function GameDetailPage() {
         </Grid>
 
         <Dialog open={openScoreDialog} onClose={() => setOpenScoreDialog(false)}>
-          <DialogTitle>Record Game Score</DialogTitle>
+          <DialogTitle>{t('gameDetail.scoreDialog')}</DialogTitle>
           <DialogContent>
             <Box display="flex" gap={2} mt={2}>
               <TextField
-                label="Team 1 Score"
+                label={t('gameDetail.team1Score')}
                 type="number"
                 value={scores.team1}
                 onChange={(e) => setScores({ ...scores, team1: Number(e.target.value) })}
                 fullWidth
               />
               <TextField
-                label="Team 2 Score"
+                label={t('gameDetail.team2Score')}
                 type="number"
                 value={scores.team2}
                 onChange={(e) => setScores({ ...scores, team2: Number(e.target.value) })}
@@ -350,9 +355,9 @@ export function GameDetailPage() {
             </Box>
           </DialogContent>
           <DialogActions>
-            <Button onClick={() => setOpenScoreDialog(false)}>Cancel</Button>
+            <Button onClick={() => setOpenScoreDialog(false)}>{t('games.cancel')}</Button>
             <Button onClick={handleSaveScore} variant="contained">
-              Save Score
+              {t('gameDetail.saveScore')}
             </Button>
           </DialogActions>
         </Dialog>

--- a/client/src/pages/GamesPage.tsx
+++ b/client/src/pages/GamesPage.tsx
@@ -18,6 +18,7 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { useI18n } from '../contexts/I18nContext';
 import { gamesApi } from '../services/api';
 import { Game } from '../types';
 import { Navigation } from '../components/Navigation';
@@ -28,6 +29,7 @@ export function GamesPage() {
   const [openDialog, setOpenDialog] = useState(false);
   const [newGame, setNewGame] = useState({ date: '', time: '', location: '' });
   const { user } = useAuth();
+  const { t } = useI18n();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -83,14 +85,14 @@ export function GamesPage() {
       <Navigation />
       <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
-          <Typography variant="h4">Games</Typography>
+          <Typography variant="h4">{t('games.title')}</Typography>
           {user?.isAdmin && (
             <Button
               variant="contained"
               startIcon={<AddIcon />}
               onClick={() => setOpenDialog(true)}
             >
-              New Game
+              {t('games.newGame')}
             </Button>
           )}
         </Box>
@@ -107,24 +109,24 @@ export function GamesPage() {
                     <Typography variant="h6">
                       {new Date(game.date).toLocaleDateString()}
                     </Typography>
-                    <Chip label={game.status} color={getStatusColor(game.status)} size="small" />
+                    <Chip label={t(`games.status.${game.status}` as 'games.status.scheduled' | 'games.status.completed' | 'games.status.cancelled')} color={getStatusColor(game.status)} size="small" />
                   </Box>
                   
                   {game.time && (
                     <Typography variant="body2" color="text.secondary">
-                      Time: {game.time}
+                      {t('games.time')}: {game.time}
                     </Typography>
                   )}
                   
                   {game.location && (
                     <Typography variant="body2" color="text.secondary">
-                      Location: {game.location}
+                      {t('games.location')}: {game.location}
                     </Typography>
                   )}
                   
                   {game.status === 'completed' && game.team1_score !== undefined && (
                     <Typography variant="h6" sx={{ mt: 2 }}>
-                      Score: {game.team1_score} - {game.team2_score}
+                      {t('games.score')}: {game.team1_score} - {game.team2_score}
                     </Typography>
                   )}
                 </CardContent>
@@ -136,17 +138,17 @@ export function GamesPage() {
         {games.length === 0 && (
           <Box textAlign="center" mt={8}>
             <Typography variant="h6" color="text.secondary">
-              No games scheduled yet
+              {t('games.none')}
             </Typography>
           </Box>
         )}
 
         <Dialog open={openDialog} onClose={() => setOpenDialog(false)} maxWidth="sm" fullWidth>
-          <DialogTitle>Create New Game</DialogTitle>
+          <DialogTitle>{t('games.createTitle')}</DialogTitle>
           <DialogContent>
             <TextField
               fullWidth
-              label="Date"
+              label={t('games.date')}
               type="date"
               value={newGame.date}
               onChange={(e) => setNewGame({ ...newGame, date: e.target.value })}
@@ -156,7 +158,7 @@ export function GamesPage() {
             />
             <TextField
               fullWidth
-              label="Time"
+              label={t('games.time')}
               type="time"
               value={newGame.time}
               onChange={(e) => setNewGame({ ...newGame, time: e.target.value })}
@@ -165,16 +167,16 @@ export function GamesPage() {
             />
             <TextField
               fullWidth
-              label="Location"
+              label={t('games.location')}
               value={newGame.location}
               onChange={(e) => setNewGame({ ...newGame, location: e.target.value })}
               margin="normal"
             />
           </DialogContent>
           <DialogActions>
-            <Button onClick={() => setOpenDialog(false)}>Cancel</Button>
+            <Button onClick={() => setOpenDialog(false)}>{t('games.cancel')}</Button>
             <Button onClick={handleCreateGame} variant="contained" disabled={!newGame.date}>
-              Create
+              {t('games.create')}
             </Button>
           </DialogActions>
         </Dialog>

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -7,9 +7,13 @@ import {
   Typography,
   Box,
   Alert,
+  FormControl,
+  Select,
+  MenuItem,
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { useI18n } from '../contexts/I18nContext';
 import SportsHockeyIcon from '@mui/icons-material/SportsHockey';
 
 export function LoginPage() {
@@ -17,6 +21,7 @@ export function LoginPage() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const { login } = useAuth();
+  const { t, language, setLanguage } = useI18n();
   const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -27,7 +32,7 @@ export function LoginPage() {
       await login(username, password);
       navigate('/');
     } catch (err: any) {
-      setError(err.response?.data?.error || 'Login failed');
+      setError(err.response?.data?.error || t('login.failed'));
     }
   };
 
@@ -42,10 +47,22 @@ export function LoginPage() {
         }}
       >
         <Paper elevation={3} sx={{ p: 4 }}>
+          <Box display="flex" justifyContent="flex-end" mb={2}>
+            <FormControl size="small" sx={{ minWidth: 140 }}>
+              <Select
+                value={language}
+                onChange={(event) => setLanguage(event.target.value as 'en' | 'fr')}
+              >
+                <MenuItem value="en">{t('lang.english')}</MenuItem>
+                <MenuItem value="fr">{t('lang.french')}</MenuItem>
+              </Select>
+            </FormControl>
+          </Box>
+
           <Box display="flex" alignItems="center" justifyContent="center" mb={3}>
             <SportsHockeyIcon sx={{ fontSize: 40, mr: 1 }} color="primary" />
             <Typography variant="h4" component="h1">
-              Hockey League
+              {t('login.title')}
             </Typography>
           </Box>
 
@@ -58,7 +75,7 @@ export function LoginPage() {
           <form onSubmit={handleSubmit}>
             <TextField
               fullWidth
-              label="Username"
+              label={t('login.username')}
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               margin="normal"
@@ -67,7 +84,7 @@ export function LoginPage() {
             />
             <TextField
               fullWidth
-              label="Password"
+              label={t('login.password')}
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -81,12 +98,12 @@ export function LoginPage() {
               size="large"
               sx={{ mt: 3 }}
             >
-              Login
+              {t('login.submit')}
             </Button>
           </form>
 
           <Typography variant="body2" color="text.secondary" sx={{ mt: 2, textAlign: 'center' }}>
-            Default admin: username: admin, password: admin123
+            {t('login.defaultAdmin')}
           </Typography>
         </Paper>
       </Box>

--- a/client/src/pages/PlayersPage.tsx
+++ b/client/src/pages/PlayersPage.tsx
@@ -29,6 +29,7 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import { useAuth } from '../contexts/AuthContext';
+import { useI18n } from '../contexts/I18nContext';
 import { playersApi } from '../services/api';
 import { Player } from '../types';
 import { Navigation } from '../components/Navigation';
@@ -60,6 +61,7 @@ export function PlayersPage() {
     goalie_rating: 5,
   });
   const { user } = useAuth();
+  const { t } = useI18n();
 
   useEffect(() => {
     loadPlayers();
@@ -157,14 +159,14 @@ export function PlayersPage() {
       <Navigation />
       <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
-          <Typography variant="h4">Players</Typography>
+          <Typography variant="h4">{t('players.title')}</Typography>
           {user?.isAdmin && (
             <Button
               variant="contained"
               startIcon={<AddIcon />}
               onClick={() => setOpenDialog(true)}
             >
-              Add Player
+              {t('players.add')}
             </Button>
           )}
         </Box>
@@ -173,17 +175,17 @@ export function PlayersPage() {
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell>Name</TableCell>
-                <TableCell>Email</TableCell>
-                <TableCell>Phone</TableCell>
-                <TableCell>Type</TableCell>
-                <TableCell>Position</TableCell>
-                <TableCell>Offense Weight</TableCell>
-                <TableCell>Defense Weight</TableCell>
-                <TableCell>Defense</TableCell>
-                <TableCell>Forward</TableCell>
-                <TableCell>Goalie</TableCell>
-                {user?.isAdmin && <TableCell align="right">Actions</TableCell>}
+                <TableCell>{t('players.name')}</TableCell>
+                <TableCell>{t('players.email')}</TableCell>
+                <TableCell>{t('players.phone')}</TableCell>
+                <TableCell>{t('players.type')}</TableCell>
+                <TableCell>{t('players.position')}</TableCell>
+                <TableCell>{t('players.offenseWeight')}</TableCell>
+                <TableCell>{t('players.defenseWeight')}</TableCell>
+                <TableCell>{t('players.defenseRating')}</TableCell>
+                <TableCell>{t('players.forwardRating')}</TableCell>
+                <TableCell>{t('players.goalieRating')}</TableCell>
+                {user?.isAdmin && <TableCell align="right">{t('players.actions')}</TableCell>}
               </TableRow>
             </TableHead>
             <TableBody>
@@ -194,12 +196,16 @@ export function PlayersPage() {
                   <TableCell>{player.phone || '-'}</TableCell>
                   <TableCell>
                     <Chip
-                      label={player.is_regular ? 'Regular' : 'Sub'}
+                      label={player.is_regular ? t('players.regular') : t('players.sub')}
                       color={player.is_regular ? 'primary' : 'default'}
                       size="small"
                     />
                   </TableCell>
-                  <TableCell sx={{ textTransform: 'capitalize' }}>{player.position}</TableCell>
+                  <TableCell sx={{ textTransform: 'capitalize' }}>
+                    {player.position === 'forward' && t('players.forward')}
+                    {player.position === 'defense' && t('players.defense')}
+                    {player.position === 'goalie' && t('players.goalie')}
+                  </TableCell>
                   <TableCell>{player.offense_weight}</TableCell>
                   <TableCell>{player.defense_weight}</TableCell>
                   <TableCell>{player.defense_rating}</TableCell>
@@ -219,21 +225,21 @@ export function PlayersPage() {
         </TableContainer>
 
         <Dialog open={openDialog} onClose={() => setOpenDialog(false)} maxWidth="sm" fullWidth>
-          <DialogTitle>Add New Player</DialogTitle>
+          <DialogTitle>{t('players.addTitle')}</DialogTitle>
           <DialogContent>
             <TextField
               fullWidth
-              label="Name"
+              label={t('players.name')}
               value={newPlayer.name}
               onChange={(e) => setNewPlayer({ ...newPlayer, name: e.target.value })}
               margin="normal"
               required
             />
             <FormControl fullWidth margin="normal">
-              <InputLabel id="new-player-position-label">Position</InputLabel>
+              <InputLabel id="new-player-position-label">{t('players.position')}</InputLabel>
               <Select
                 labelId="new-player-position-label"
-                label="Position"
+                label={t('players.position')}
                 value={newPlayer.position}
                 onChange={(e) =>
                   setNewPlayer({
@@ -242,14 +248,14 @@ export function PlayersPage() {
                   })
                 }
               >
-                <MenuItem value="forward">Forward</MenuItem>
-                <MenuItem value="defense">Defense</MenuItem>
-                <MenuItem value="goalie">Goalie</MenuItem>
+                <MenuItem value="forward">{t('players.forward')}</MenuItem>
+                <MenuItem value="defense">{t('players.defense')}</MenuItem>
+                <MenuItem value="goalie">{t('players.goalie')}</MenuItem>
               </Select>
             </FormControl>
             <TextField
               fullWidth
-              label="Email"
+              label={t('players.email')}
               type="email"
               value={newPlayer.email}
               onChange={(e) => setNewPlayer({ ...newPlayer, email: e.target.value })}
@@ -257,7 +263,7 @@ export function PlayersPage() {
             />
             <TextField
               fullWidth
-              label="Phone"
+              label={t('players.phone')}
               value={newPlayer.phone}
               onChange={(e) => setNewPlayer({ ...newPlayer, phone: e.target.value })}
               margin="normal"
@@ -271,11 +277,11 @@ export function PlayersPage() {
                   }
                 />
               }
-              label="Regular Player"
+              label={t('players.regularToggle')}
             />
             <TextField
               fullWidth
-              label="Offense Weight (0-10)"
+              label={`${t('players.offenseWeight')} (0-10)`}
               type="number"
               value={newPlayer.offense_weight}
               onChange={(e) =>
@@ -286,7 +292,7 @@ export function PlayersPage() {
             />
             <TextField
               fullWidth
-              label="Defense Weight (0-10)"
+              label={`${t('players.defenseWeight')} (0-10)`}
               type="number"
               value={newPlayer.defense_weight}
               onChange={(e) =>
@@ -297,7 +303,7 @@ export function PlayersPage() {
             />
             <TextField
               fullWidth
-              label="Defense Rating (0-10)"
+              label={`${t('players.defenseRating')} (0-10)`}
               type="number"
               value={newPlayer.defense_rating}
               onChange={(e) =>
@@ -308,7 +314,7 @@ export function PlayersPage() {
             />
             <TextField
               fullWidth
-              label="Forward Rating (0-10)"
+              label={`${t('players.forwardRating')} (0-10)`}
               type="number"
               value={newPlayer.forward_rating}
               onChange={(e) =>
@@ -319,7 +325,7 @@ export function PlayersPage() {
             />
             <TextField
               fullWidth
-              label="Goalie Rating (0-10)"
+              label={`${t('players.goalieRating')} (0-10)`}
               type="number"
               value={newPlayer.goalie_rating}
               onChange={(e) =>
@@ -330,24 +336,24 @@ export function PlayersPage() {
             />
           </DialogContent>
           <DialogActions>
-            <Button onClick={() => setOpenDialog(false)}>Cancel</Button>
+            <Button onClick={() => setOpenDialog(false)}>{t('players.cancel')}</Button>
             <Button onClick={handleCreatePlayer} variant="contained" disabled={!newPlayer.name}>
-              Add Player
+              {t('players.addPlayer')}
             </Button>
           </DialogActions>
         </Dialog>
 
         <Dialog open={openEditDialog} onClose={() => setOpenEditDialog(false)} maxWidth="sm" fullWidth>
-          <DialogTitle>Update Player Ratings</DialogTitle>
+          <DialogTitle>{t('players.updateTitle')}</DialogTitle>
           <DialogContent>
             <Typography variant="subtitle1" sx={{ mt: 1 }}>
               {editingPlayer?.name}
             </Typography>
             <FormControl fullWidth margin="normal">
-              <InputLabel id="edit-player-position-label">Position</InputLabel>
+              <InputLabel id="edit-player-position-label">{t('players.position')}</InputLabel>
               <Select
                 labelId="edit-player-position-label"
-                label="Position"
+                label={t('players.position')}
                 value={editRatings.position}
                 onChange={(e) =>
                   setEditRatings({
@@ -356,14 +362,14 @@ export function PlayersPage() {
                   })
                 }
               >
-                <MenuItem value="forward">Forward</MenuItem>
-                <MenuItem value="defense">Defense</MenuItem>
-                <MenuItem value="goalie">Goalie</MenuItem>
+                <MenuItem value="forward">{t('players.forward')}</MenuItem>
+                <MenuItem value="defense">{t('players.defense')}</MenuItem>
+                <MenuItem value="goalie">{t('players.goalie')}</MenuItem>
               </Select>
             </FormControl>
             <TextField
               fullWidth
-              label="Offense Weight (0-10)"
+              label={`${t('players.offenseWeight')} (0-10)`}
               type="number"
               value={editRatings.offense_weight}
               onChange={(e) =>
@@ -377,7 +383,7 @@ export function PlayersPage() {
             />
             <TextField
               fullWidth
-              label="Defense Weight (0-10)"
+              label={`${t('players.defenseWeight')} (0-10)`}
               type="number"
               value={editRatings.defense_weight}
               onChange={(e) =>
@@ -391,7 +397,7 @@ export function PlayersPage() {
             />
             <TextField
               fullWidth
-              label="Defense Rating (0-10)"
+              label={`${t('players.defenseRating')} (0-10)`}
               type="number"
               value={editRatings.defense_rating}
               onChange={(e) =>
@@ -405,7 +411,7 @@ export function PlayersPage() {
             />
             <TextField
               fullWidth
-              label="Forward Rating (0-10)"
+              label={`${t('players.forwardRating')} (0-10)`}
               type="number"
               value={editRatings.forward_rating}
               onChange={(e) =>
@@ -419,7 +425,7 @@ export function PlayersPage() {
             />
             <TextField
               fullWidth
-              label="Goalie Rating (0-10)"
+              label={`${t('players.goalieRating')} (0-10)`}
               type="number"
               value={editRatings.goalie_rating}
               onChange={(e) =>
@@ -433,9 +439,9 @@ export function PlayersPage() {
             />
           </DialogContent>
           <DialogActions>
-            <Button onClick={() => setOpenEditDialog(false)}>Cancel</Button>
+            <Button onClick={() => setOpenEditDialog(false)}>{t('players.cancel')}</Button>
             <Button onClick={handleSaveRatings} variant="contained" disabled={!editingPlayer}>
-              Save Ratings
+              {t('players.save')}
             </Button>
           </DialogActions>
         </Dialog>


### PR DESCRIPTION
Added bilingual support (en + fr) across the app and added Copilot guidance to enforce it going forward.

What I changed

Added a global i18n system:

I18nContext.tsx
Includes English and French translation dictionaries
Persists selected language in localStorage
Provides t(...), language, and setLanguage(...)
Wired i18n provider into app root:

App.tsx
Added language switchers:

In authenticated nav: Navigation.tsx
On login page (before auth): LoginPage.tsx
Replaced hardcoded UI strings with translation keys in main pages:

LoginPage.tsx
GamesPage.tsx
GameDetailPage.tsx
PlayersPage.tsx
Includes labels, buttons, dialog titles, status text, and table headers
Added Copilot instructions so future changes always keep both languages:

copilot-instructions.md