### PR TITLE
add forward positions

### DIFF
--- a/client/src/contexts/I18nContext.tsx
+++ b/client/src/contexts/I18nContext.tsx
@@ -59,6 +59,10 @@ type TranslationKey =
   | 'players.forward'
   | 'players.defense'
   | 'players.goalie'
+  | 'players.center'
+  | 'players.winger'
+  | 'players.forwardPositions'
+  | 'players.centerWinger'
   | 'players.cancel'
   | 'players.save'
   | 'players.addPlayer'
@@ -202,6 +206,10 @@ const translations: Record<Language, Record<TranslationKey, string>> = {
     'players.forward': 'Forward',
     'players.defense': 'Defense',
     'players.goalie': 'Goalie',
+    'players.center': 'Center',
+    'players.winger': 'Winger',
+    'players.forwardPositions': 'Forward Positions',
+    'players.centerWinger': 'C/W',
     'players.cancel': 'Cancel',
     'players.save': 'Save Ratings',
     'players.addPlayer': 'Add Player',
@@ -346,6 +354,10 @@ const translations: Record<Language, Record<TranslationKey, string>> = {
     'players.forward': 'Attaquant',
     'players.defense': 'Defenseur',
     'players.goalie': 'Gardien',
+    'players.center': 'Centre',
+    'players.winger': 'Ailier',
+    'players.forwardPositions': 'Positions attaque',
+    'players.centerWinger': 'C/A',
     'players.cancel': 'Annuler',
     'players.save': 'Enregistrer les cotes',
     'players.addPlayer': 'Ajouter le joueur',

--- a/client/src/pages/GameDetailPage.tsx
+++ b/client/src/pages/GameDetailPage.tsx
@@ -263,9 +263,45 @@ export function GameDetailPage() {
   const canUpdateAttendance = (attendanceUserId?: number) =>
     Boolean(user && (user.isAdmin || attendanceUserId === user.id));
 
+  const renderPositionGroup = (label: string, players: Team[]) => {
+    if (players.length === 0) return null;
+    return (
+      <>
+        <Typography variant="subtitle2" sx={{ mt: 1, fontWeight: 'bold' }}>
+          {label}
+        </Typography>
+        <List dense>
+          {players.map((player) => (
+            <ListItem key={player.player_id}>
+              <ListItemText primary={player.player_name} />
+            </ListItem>
+          ))}
+        </List>
+      </>
+    );
+  };
+
   const groupPlayersByPosition = (players: Team[]) => {
+    const parseFwd = (fp?: string): ('center' | 'winger')[] => {
+      if (!fp) return ['center', 'winger'];
+      try {
+        const parsed = JSON.parse(fp);
+        if (Array.isArray(parsed)) {
+          return parsed.filter((v: string) => v === 'center' || v === 'winger');
+        }
+      } catch {}
+      return ['center', 'winger'];
+    };
+
+    const forwards = players.filter(p => p.position === 'forward');
+    const centers = forwards.filter(p => parseFwd(p.forward_positions).includes('center') && !parseFwd(p.forward_positions).includes('winger'));
+    const wingers = forwards.filter(p => parseFwd(p.forward_positions).includes('winger') && !parseFwd(p.forward_positions).includes('center'));
+    const both = forwards.filter(p => parseFwd(p.forward_positions).includes('center') && parseFwd(p.forward_positions).includes('winger'));
+
     return {
-      forwards: players.filter(p => p.position === 'forward'),
+      centers,
+      wingers,
+      both,
       defense: players.filter(p => p.position === 'defense'),
       goalies: players.filter(p => p.position === 'goalie'),
     };
@@ -483,122 +519,49 @@ export function GameDetailPage() {
                         {team1[0]?.team_name || t('gameDetail.team1')}
                       </Typography>
                     )}
-                    {(() => {
-                      const grouped = groupPlayersByPosition(team1);
-                      return (
-                        <>
-                          {grouped.forwards.length > 0 && (
-                            <>
-                              <Typography variant="subtitle2" sx={{ mt: 1, fontWeight: 'bold' }}>
-                                F
-                              </Typography>
-                              <List dense>
-                                {grouped.forwards.map((player) => (
-                                  <ListItem key={player.player_id}>
-                                    <ListItemText primary={player.player_name} />
-                                  </ListItem>
-                                ))}
-                              </List>
-                            </>
-                          )}
-                          {grouped.defense.length > 0 && (
-                            <>
-                              <Typography variant="subtitle2" sx={{ mt: 1, fontWeight: 'bold' }}>
-                                D
-                              </Typography>
-                              <List dense>
-                                {grouped.defense.map((player) => (
-                                  <ListItem key={player.player_id}>
-                                    <ListItemText primary={player.player_name} />
-                                  </ListItem>
-                                ))}
-                              </List>
-                            </>
-                          )}
-                          {grouped.goalies.length > 0 && (
-                            <>
-                              <Typography variant="subtitle2" sx={{ mt: 1, fontWeight: 'bold' }}>
-                                Goalie
-                              </Typography>
-                              <List dense>
-                                {grouped.goalies.map((player) => (
-                                  <ListItem key={player.player_id}>
-                                    <ListItemText primary={player.player_name} />
-                                  </ListItem>
-                                ))}
-                              </List>
-                            </>
-                          )}
-                        </>
-                      );
-                    })()}
-                  </Grid>
-                  <Grid item xs={6}>
-                    {user?.isAdmin ? (
-                      <TextField
-                        fullWidth
-                        variant="outlined"
-                        size="small"
-                        value={editingTeam2Name || team2[0]?.team_name || t('gameDetail.team2')}
-                        onChange={(e) => handleTeamNameChange(2, e.target.value)}
-                        onBlur={() => handleTeamNameSave(2)}
-                        onKeyPress={(e) => e.key === 'Enter' && handleTeamNameSave(2)}
-                        sx={{ mb: 1 }}
-                      />
-                    ) : (
-                      <Typography variant="h6" color="secondary">
-                        {team2[0]?.team_name || t('gameDetail.team2')}
-                      </Typography>
-                    )}
-                    {(() => {
-                      const grouped = groupPlayersByPosition(team2);
-                      return (
-                        <>
-                          {grouped.forwards.length > 0 && (
-                            <>
-                              <Typography variant="subtitle2" sx={{ mt: 1, fontWeight: 'bold' }}>
-                                F
-                              </Typography>
-                              <List dense>
-                                {grouped.forwards.map((player) => (
-                                  <ListItem key={player.player_id}>
-                                    <ListItemText primary={player.player_name} />
-                                  </ListItem>
-                                ))}
-                              </List>
-                            </>
-                          )}
-                          {grouped.defense.length > 0 && (
-                            <>
-                              <Typography variant="subtitle2" sx={{ mt: 1, fontWeight: 'bold' }}>
-                                D
-                              </Typography>
-                              <List dense>
-                                {grouped.defense.map((player) => (
-                                  <ListItem key={player.player_id}>
-                                    <ListItemText primary={player.player_name} />
-                                  </ListItem>
-                                ))}
-                              </List>
-                            </>
-                          )}
-                          {grouped.goalies.length > 0 && (
-                            <>
-                              <Typography variant="subtitle2" sx={{ mt: 1, fontWeight: 'bold' }}>
-                                Goalie
-                              </Typography>
-                              <List dense>
-                                {grouped.goalies.map((player) => (
-                                  <ListItem key={player.player_id}>
-                                    <ListItemText primary={player.player_name} />
-                                  </ListItem>
-                                ))}
-                              </List>
-                            </>
-                          )}
-                        </>
-                      );
-                    })()}
+        {(() => {
+        const grouped = groupPlayersByPosition(team1);
+        return (
+        <>
+        {renderPositionGroup('C', grouped.centers)}
+        {renderPositionGroup('W', grouped.wingers)}
+        {renderPositionGroup('C/W', grouped.both)}
+        {grouped.centers.length === 0 && grouped.wingers.length === 0 && grouped.both.length === 0 && grouped.defense.length === 0 && grouped.goalies.length === 0 && null}
+        {renderPositionGroup('D', grouped.defense)}
+        {renderPositionGroup('G', grouped.goalies)}
+        </>
+        );
+        })()}
+        </Grid>
+        <Grid item xs={6}>
+        {user?.isAdmin ? (
+        <TextField
+        fullWidth
+        variant="outlined"
+        size="small"
+        value={editingTeam2Name || team2[0]?.team_name || t('gameDetail.team2')}
+        onChange={(e) => handleTeamNameChange(2, e.target.value)}
+        onBlur={() => handleTeamNameSave(2)}
+        onKeyPress={(e) => e.key === 'Enter' && handleTeamNameSave(2)}
+        sx={{ mb: 1 }}
+        />
+        ) : (
+        <Typography variant="h6" color="secondary">
+        {team2[0]?.team_name || t('gameDetail.team2')}
+        </Typography>
+        )}
+        {(() => {
+        const grouped = groupPlayersByPosition(team2);
+        return (
+        <>
+        {renderPositionGroup('C', grouped.centers)}
+        {renderPositionGroup('W', grouped.wingers)}
+        {renderPositionGroup('C/W', grouped.both)}
+        {renderPositionGroup('D', grouped.defense)}
+        {renderPositionGroup('G', grouped.goalies)}
+        </>
+        );
+        })()}
                   </Grid>
                 </Grid>
               )}

--- a/client/src/pages/PlayersPage.tsx
+++ b/client/src/pages/PlayersPage.tsx
@@ -57,6 +57,7 @@ export function PlayersPage() {
   const [newPlayer, setNewPlayer] = useState({
     name: '',
     position: 'forward' as 'forward' | 'defense' | 'goalie',
+    forward_positions: ['center', 'winger'] as ('center' | 'winger')[],
     email: '',
     phone: '',
     is_regular: true,
@@ -68,6 +69,7 @@ export function PlayersPage() {
   });
   const [editRatings, setEditRatings] = useState({
     position: 'forward' as 'forward' | 'defense' | 'goalie',
+    forward_positions: ['center', 'winger'] as ('center' | 'winger')[],
     offense_weight: 5,
     defense_weight: 5,
     defense_rating: 5,
@@ -96,20 +98,24 @@ export function PlayersPage() {
 
   const handleCreatePlayer = async () => {
     try {
-      await playersApi.create(newPlayer);
-      setOpenDialog(false);
-      setNewPlayer({
-        name: '',
-        position: 'forward',
-        email: '',
-        phone: '',
-        is_regular: true,
-        offense_weight: 5,
-        defense_weight: 5,
-        defense_rating: 5,
-        forward_rating: 5,
-        goalie_rating: 5,
-      });
+    await playersApi.create({
+      ...newPlayer,
+      forward_positions: newPlayer.position === 'forward' ? newPlayer.forward_positions : undefined,
+    });
+    setOpenDialog(false);
+    setNewPlayer({
+      name: '',
+      position: 'forward',
+      forward_positions: ['center', 'winger'],
+      email: '',
+      phone: '',
+      is_regular: true,
+      offense_weight: 5,
+      defense_weight: 5,
+      defense_rating: 5,
+      forward_rating: 5,
+      goalie_rating: 5,
+    });
       loadPlayers();
     } catch (error) {
       console.error('Failed to create player:', error);
@@ -123,6 +129,7 @@ export function PlayersPage() {
       forward_rating: player.forward_rating,
       goalie_rating: player.goalie_rating,
       position: player.position,
+      forward_positions: parseForwardPositions(player.forward_positions),
       offense_weight: player.offense_weight,
       defense_weight: player.defense_weight,
     });
@@ -198,6 +205,37 @@ export function PlayersPage() {
 
   const clampRating = (value: number) => Math.max(0, Math.min(10, value));
 
+  const parseForwardPositions = (fp?: string): ('center' | 'winger')[] => {
+    if (!fp) return ['center', 'winger'];
+    try {
+      const parsed = JSON.parse(fp);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((v: string) => v === 'center' || v === 'winger');
+      }
+    } catch {}
+    return ['center', 'winger'];
+  };
+
+  const formatForwardPositions = (positions: ('center' | 'winger')[]): string => {
+    const hasCenter = positions.includes('center');
+    const hasWinger = positions.includes('winger');
+    if (hasCenter && hasWinger) return t('players.centerWinger');
+    if (hasCenter) return t('players.center');
+    if (hasWinger) return t('players.winger');
+    return t('players.centerWinger');
+  };
+
+  const toggleForwardPosition = (
+    current: ('center' | 'winger')[],
+    pos: 'center' | 'winger'
+  ): ('center' | 'winger')[] => {
+    if (current.includes(pos)) {
+      const next = current.filter(p => p !== pos);
+      return next.length > 0 ? next : current;
+    }
+    return [...current, pos];
+  };
+
   const handleSaveRatings = async () => {
     if (!editingPlayer) {
       return;
@@ -207,6 +245,7 @@ export function PlayersPage() {
       await playersApi.update(editingPlayer.id, {
         name: editingPlayer.name,
         position: editRatings.position,
+        forward_positions: editRatings.position === 'forward' ? editRatings.forward_positions : undefined,
         email: editingPlayer.email,
         phone: editingPlayer.phone,
         is_regular: Boolean(editingPlayer.is_regular),
@@ -293,11 +332,11 @@ export function PlayersPage() {
                       size="small"
                     />
                   </TableCell>
-                  <TableCell sx={{ textTransform: 'capitalize' }}>
-                    {player.position === 'forward' && t('players.forward')}
-                    {player.position === 'defense' && t('players.defense')}
-                    {player.position === 'goalie' && t('players.goalie')}
-                  </TableCell>
+    <TableCell sx={{ textTransform: 'capitalize' }}>
+    {player.position === 'forward' && `${t('players.forward')} (${formatForwardPositions(parseForwardPositions(player.forward_positions))})`}
+    {player.position === 'defense' && t('players.defense')}
+    {player.position === 'goalie' && t('players.goalie')}
+    </TableCell>
                   <TableCell>{player.offense_weight}</TableCell>
                   <TableCell>{player.defense_weight}</TableCell>
                   <TableCell>{player.defense_rating}</TableCell>
@@ -335,24 +374,57 @@ export function PlayersPage() {
               margin="normal"
               required
             />
-            <FormControl fullWidth margin="normal">
-              <InputLabel id="new-player-position-label">{t('players.position')}</InputLabel>
-              <Select
-                labelId="new-player-position-label"
-                label={t('players.position')}
-                value={newPlayer.position}
-                onChange={(e) =>
-                  setNewPlayer({
-                    ...newPlayer,
-                    position: e.target.value as 'forward' | 'defense' | 'goalie',
-                  })
-                }
-              >
-                <MenuItem value="forward">{t('players.forward')}</MenuItem>
-                <MenuItem value="defense">{t('players.defense')}</MenuItem>
-                <MenuItem value="goalie">{t('players.goalie')}</MenuItem>
-              </Select>
-            </FormControl>
+        <FormControl fullWidth margin="normal">
+        <InputLabel id="new-player-position-label">{t('players.position')}</InputLabel>
+        <Select
+        labelId="new-player-position-label"
+        label={t('players.position')}
+        value={newPlayer.position}
+        onChange={(e) =>
+        setNewPlayer({
+        ...newPlayer,
+        position: e.target.value as 'forward' | 'defense' | 'goalie',
+        forward_positions: e.target.value !== 'forward' ? [] : (newPlayer.forward_positions.length > 0 ? newPlayer.forward_positions : ['center', 'winger']),
+        })
+        }
+        >
+        <MenuItem value="forward">{t('players.forward')}</MenuItem>
+        <MenuItem value="defense">{t('players.defense')}</MenuItem>
+        <MenuItem value="goalie">{t('players.goalie')}</MenuItem>
+        </Select>
+        </FormControl>
+        {newPlayer.position === 'forward' && (
+        <Box display="flex" gap={2} mt={1} mb={1}>
+        <FormControlLabel
+        control={
+        <Checkbox
+        checked={newPlayer.forward_positions.includes('center')}
+        onChange={() =>
+        setNewPlayer({
+        ...newPlayer,
+        forward_positions: toggleForwardPosition(newPlayer.forward_positions, 'center'),
+        })
+        }
+        />
+        }
+        label={t('players.center')}
+        />
+        <FormControlLabel
+        control={
+        <Checkbox
+        checked={newPlayer.forward_positions.includes('winger')}
+        onChange={() =>
+        setNewPlayer({
+        ...newPlayer,
+        forward_positions: toggleForwardPosition(newPlayer.forward_positions, 'winger'),
+        })
+        }
+        />
+        }
+        label={t('players.winger')}
+        />
+        </Box>
+        )}
             <TextField
               fullWidth
               label={t('players.email')}
@@ -449,24 +521,57 @@ export function PlayersPage() {
             <Typography variant="subtitle1" sx={{ mt: 1 }}>
               {editingPlayer?.name}
             </Typography>
-            <FormControl fullWidth margin="normal">
-              <InputLabel id="edit-player-position-label">{t('players.position')}</InputLabel>
-              <Select
-                labelId="edit-player-position-label"
-                label={t('players.position')}
-                value={editRatings.position}
-                onChange={(e) =>
-                  setEditRatings({
-                    ...editRatings,
-                    position: e.target.value as 'forward' | 'defense' | 'goalie',
-                  })
-                }
-              >
-                <MenuItem value="forward">{t('players.forward')}</MenuItem>
-                <MenuItem value="defense">{t('players.defense')}</MenuItem>
-                <MenuItem value="goalie">{t('players.goalie')}</MenuItem>
-              </Select>
-            </FormControl>
+      <FormControl fullWidth margin="normal">
+      <InputLabel id="edit-player-position-label">{t('players.position')}</InputLabel>
+      <Select
+      labelId="edit-player-position-label"
+      label={t('players.position')}
+      value={editRatings.position}
+      onChange={(e) =>
+      setEditRatings({
+      ...editRatings,
+      position: e.target.value as 'forward' | 'defense' | 'goalie',
+      forward_positions: e.target.value !== 'forward' ? [] : (editRatings.forward_positions.length > 0 ? editRatings.forward_positions : ['center', 'winger']),
+      })
+      }
+      >
+      <MenuItem value="forward">{t('players.forward')}</MenuItem>
+      <MenuItem value="defense">{t('players.defense')}</MenuItem>
+      <MenuItem value="goalie">{t('players.goalie')}</MenuItem>
+      </Select>
+      </FormControl>
+      {editRatings.position === 'forward' && (
+      <Box display="flex" gap={2} mt={1} mb={1}>
+      <FormControlLabel
+      control={
+      <Checkbox
+      checked={editRatings.forward_positions.includes('center')}
+      onChange={() =>
+      setEditRatings({
+      ...editRatings,
+      forward_positions: toggleForwardPosition(editRatings.forward_positions, 'center'),
+      })
+      }
+      />
+      }
+      label={t('players.center')}
+      />
+      <FormControlLabel
+      control={
+      <Checkbox
+      checked={editRatings.forward_positions.includes('winger')}
+      onChange={() =>
+      setEditRatings({
+      ...editRatings,
+      forward_positions: toggleForwardPosition(editRatings.forward_positions, 'winger'),
+      })
+      }
+      />
+      }
+      label={t('players.winger')}
+      />
+      </Box>
+      )}
             <TextField
               fullWidth
               label={`${t('players.offenseWeight')} (0-10)`}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -16,6 +16,7 @@ export interface Player {
   user_id?: number;
   name: string;
   position: 'forward' | 'defense' | 'goalie';
+  forward_positions?: string;
   email?: string;
   phone?: string;
   is_regular: number;
@@ -113,6 +114,7 @@ export interface Team {
   player_name: string;
   team_name?: string;
   position: 'forward' | 'defense' | 'goalie';
+  forward_positions?: string;
 }
 
 export interface GameWithDetails extends Game {

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -101,19 +101,21 @@ async function seedTestData() {
     // Create 22 regular players: 12 forwards, 8 defensemen, 2 goalies
     const regularPlayers = [];
 
-    // 12 Forwards
-    for (let i = 0; i < 12; i++) {
-      regularPlayers.push({
-        name: getRandomName(),
-        position: 'forward' as const,
-        is_regular: 1,
-        offense_weight: getRandomRating(6, 10),
-        defense_weight: getRandomRating(4, 8),
-        defense_rating: getRandomRating(4, 7),
-        forward_rating: getRandomRating(6, 10),
-        goalie_rating: getRandomRating(2, 4),
-      });
-    }
+  // 12 Forwards
+  for (let i = 0; i < 12; i++) {
+    const fwdPos = i < 5 ? '["center","winger"]' : i < 8 ? '["center"]' : '["winger"]';
+    regularPlayers.push({
+      name: getRandomName(),
+      position: 'forward' as const,
+      forward_positions: fwdPos,
+      is_regular: 1,
+      offense_weight: getRandomRating(6, 10),
+      defense_weight: getRandomRating(4, 8),
+      defense_rating: getRandomRating(4, 7),
+      forward_rating: getRandomRating(6, 10),
+      goalie_rating: getRandomRating(2, 4),
+    });
+  }
 
     // 8 Defensemen
     for (let i = 0; i < 8; i++) {
@@ -146,19 +148,21 @@ async function seedTestData() {
     // Create subs: 3 forwards, 2 defensemen, 1 goalie
     const subPlayers = [];
 
-    // 3 Forward subs
-    for (let i = 0; i < 3; i++) {
-      subPlayers.push({
-        name: getRandomName(),
-        position: 'forward' as const,
-        is_regular: 0,
-        offense_weight: getRandomRating(5, 9),
-        defense_weight: getRandomRating(3, 7),
-        defense_rating: getRandomRating(3, 6),
-        forward_rating: getRandomRating(5, 9),
-        goalie_rating: getRandomRating(2, 3),
-      });
-    }
+  // 3 Forward subs
+  for (let i = 0; i < 3; i++) {
+    const fwdPos = i === 0 ? '["center","winger"]' : i === 1 ? '["center"]' : '["winger"]';
+    subPlayers.push({
+      name: getRandomName(),
+      position: 'forward' as const,
+      forward_positions: fwdPos,
+      is_regular: 0,
+      offense_weight: getRandomRating(5, 9),
+      defense_weight: getRandomRating(3, 7),
+      defense_rating: getRandomRating(3, 6),
+      forward_rating: getRandomRating(5, 9),
+      goalie_rating: getRandomRating(2, 3),
+    });
+  }
 
     // 2 Defense subs
     for (let i = 0; i < 2; i++) {
@@ -190,22 +194,23 @@ async function seedTestData() {
 
     // Insert all players
     for (const player of allPlayers) {
-      const result = await runAsync(
-        `INSERT INTO players
-        (league_id, name, position, email, is_regular, offense_weight, defense_weight, defense_rating, forward_rating, goalie_rating)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [
-          testLeagueId,
-          player.name,
-          player.position,
-          getRandomEmail(player.name),
-          player.is_regular,
-          player.offense_weight,
-          player.defense_weight,
-          player.defense_rating,
-          player.forward_rating,
-          player.goalie_rating,
-        ]
+    const result = await runAsync(
+      `INSERT INTO players
+      (league_id, name, position, forward_positions, email, is_regular, offense_weight, defense_weight, defense_rating, forward_rating, goalie_rating)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        testLeagueId,
+        player.name,
+        player.position,
+        player.forward_positions || null,
+        getRandomEmail(player.name),
+        player.is_regular,
+        player.offense_weight,
+        player.defense_weight,
+        player.defense_rating,
+        player.forward_rating,
+        player.goalie_rating,
+      ]
       );
 
       await runAsync('INSERT INTO player_leagues (player_id, league_id) VALUES (?, ?)', [
@@ -277,15 +282,16 @@ export async function initializeDatabase() {
         phone TEXT,
         is_regular INTEGER DEFAULT 1,
         is_active INTEGER DEFAULT 1,
-        offense_weight INTEGER DEFAULT 5,
-        defense_weight INTEGER DEFAULT 5,
-        defense_rating INTEGER DEFAULT 5,
-        forward_rating INTEGER DEFAULT 5,
-        goalie_rating INTEGER DEFAULT 5,
-        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        FOREIGN KEY (league_id) REFERENCES leagues(id),
-        FOREIGN KEY (user_id) REFERENCES users(id)
-      )
+  forward_positions TEXT,
+  offense_weight INTEGER DEFAULT 5,
+  defense_weight INTEGER DEFAULT 5,
+  defense_rating INTEGER DEFAULT 5,
+  forward_rating INTEGER DEFAULT 5,
+  goalie_rating INTEGER DEFAULT 5,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (league_id) REFERENCES leagues(id),
+  FOREIGN KEY (user_id) REFERENCES users(id)
+  )
     `);
 
     // Player-league membership table
@@ -418,9 +424,14 @@ export async function initializeDatabase() {
       await runAsync('ALTER TABLE players ADD COLUMN forward_rating INTEGER DEFAULT 5');
     }
 
-    if (!(await columnExists('players', 'goalie_rating'))) {
-      await runAsync('ALTER TABLE players ADD COLUMN goalie_rating INTEGER DEFAULT 5');
-    }
+  if (!(await columnExists('players', 'goalie_rating'))) {
+    await runAsync('ALTER TABLE players ADD COLUMN goalie_rating INTEGER DEFAULT 5');
+  }
+
+  if (!(await columnExists('players', 'forward_positions'))) {
+    await runAsync("ALTER TABLE players ADD COLUMN forward_positions TEXT");
+    await runAsync("UPDATE players SET forward_positions = '[\"center\",\"winger\"]' WHERE position = 'forward'");
+  }
 
     if (!(await columnExists('games', 'league_id'))) {
       await runAsync('ALTER TABLE games ADD COLUMN league_id INTEGER REFERENCES leagues(id)');
@@ -464,9 +475,9 @@ export async function initializeDatabase() {
     await runAsync('CREATE INDEX IF NOT EXISTS idx_notification_logs_created_at ON notification_logs(created_at)');
     await runAsync('CREATE INDEX IF NOT EXISTS idx_games_series_id ON games(series_id)');
     await runAsync('CREATE INDEX IF NOT EXISTS idx_teams_series_id ON teams(series_id)');
-    await runAsync('CREATE INDEX IF NOT EXISTS idx_series_league_id ON series(league_id)');
+  await runAsync('CREATE INDEX IF NOT EXISTS idx_series_league_id ON series(league_id)');
 
-    // Backfill player-league memberships from legacy players.league_id.
+  // Backfill player-league memberships from legacy players.league_id.
     await runAsync(`
       INSERT OR IGNORE INTO player_leagues (player_id, league_id)
       SELECT id, league_id FROM players WHERE league_id IS NOT NULL
@@ -493,26 +504,31 @@ export async function initializeDatabase() {
     `);
 
     // League-specific player ratings table
-    await runAsync(`
-      CREATE TABLE IF NOT EXISTS player_league_ratings (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        player_id INTEGER NOT NULL,
-        league_id INTEGER NOT NULL,
-        position TEXT,
-        offense_weight INTEGER,
-        defense_weight INTEGER,
-        defense_rating INTEGER,
-        forward_rating INTEGER,
-        goalie_rating INTEGER,
-        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE CASCADE,
-        FOREIGN KEY (league_id) REFERENCES leagues(id) ON DELETE CASCADE,
-        UNIQUE(player_id, league_id)
-      )
-    `);
+  await runAsync(`
+    CREATE TABLE IF NOT EXISTS player_league_ratings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    player_id INTEGER NOT NULL,
+    league_id INTEGER NOT NULL,
+    position TEXT,
+    forward_positions TEXT,
+    offense_weight INTEGER,
+    defense_weight INTEGER,
+    defense_rating INTEGER,
+    forward_rating INTEGER,
+    goalie_rating INTEGER,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE CASCADE,
+    FOREIGN KEY (league_id) REFERENCES leagues(id) ON DELETE CASCADE,
+    UNIQUE(player_id, league_id)
+  )
+  `);
 
-    // Create default admin user if not exists
+  if (!(await columnExists('player_league_ratings', 'forward_positions'))) {
+    await runAsync('ALTER TABLE player_league_ratings ADD COLUMN forward_positions TEXT');
+  }
+
+  // Create default admin user if not exists
     const adminExists = await getAsync('SELECT id FROM users WHERE username = ?', ['admin']);
     if (!adminExists) {
       const hashedPassword = bcrypt.hashSync('admin123', 10);

--- a/server/src/routes/games.ts
+++ b/server/src/routes/games.ts
@@ -91,13 +91,13 @@ router.get('/:id', authenticateToken, async (req: AuthRequest, res: Response) =>
     // Get teams, from series if game belongs to one
     const teamTarget = game.series_id ? 't.series_id = ?' : 't.game_id = ?';
     const teamTargetId = game.series_id || game.id;
-    const teams = await allAsync(`
-      SELECT t.team_number, t.player_id, p.name as player_name, p.position, t.team_name
-      FROM teams t
-      JOIN players p ON t.player_id = p.id
-      JOIN player_leagues pl ON pl.player_id = p.id
-      WHERE ${teamTarget} AND pl.league_id = ?
-      ORDER BY t.team_number, p.name
+  const teams = await allAsync(`
+    SELECT t.team_number, t.player_id, p.name as player_name, p.position, p.forward_positions, t.team_name
+    FROM teams t
+    JOIN players p ON t.player_id = p.id
+    JOIN player_leagues pl ON pl.player_id = p.id
+    WHERE ${teamTarget} AND pl.league_id = ?
+    ORDER BY t.team_number, p.name
     `, [teamTargetId, req.leagueId]) as TeamWithPlayer[];
 
     const notificationLogs = await allAsync(

--- a/server/src/routes/players.ts
+++ b/server/src/routes/players.ts
@@ -1,6 +1,6 @@
 import express, { Response } from 'express';
 import { allAsync, getAsync, runAsync } from '../database.js';
-import { Player } from '../types.js';
+import { Player, ForwardPosition } from '../types.js';
 import { authenticateToken, requireAdmin, AuthRequest } from '../middleware/auth.js';
 
 const router = express.Router();
@@ -33,6 +33,21 @@ function normalizePosition(value: unknown): 'forward' | 'defense' | 'goalie' {
   return 'forward';
 }
 
+function normalizeForwardPositions(value: unknown, position: 'forward' | 'defense' | 'goalie'): string | null {
+  if (position !== 'forward') {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    const valid = value.filter((v): v is ForwardPosition => v === 'center' || v === 'winger');
+    if (valid.length > 0) {
+      return JSON.stringify(valid);
+    }
+  }
+
+  return JSON.stringify(['center', 'winger']);
+}
+
 // Get all players
 router.get('/', authenticateToken, async (req: AuthRequest, res: Response) => {
   try {
@@ -42,21 +57,23 @@ router.get('/', authenticateToken, async (req: AuthRequest, res: Response) => {
 
     const players = await allAsync(
       `SELECT 
-        p.*,
-        COALESCE(plr.position, p.position) as effective_position,
-        COALESCE(plr.offense_weight, p.offense_weight) as effective_offense_weight,
-        COALESCE(plr.defense_weight, p.defense_weight) as effective_defense_weight,
-        COALESCE(plr.defense_rating, p.defense_rating) as effective_defense_rating,
-        COALESCE(plr.forward_rating, p.forward_rating) as effective_forward_rating,
-        COALESCE(plr.goalie_rating, p.goalie_rating) as effective_goalie_rating
-       FROM players p
-       JOIN player_leagues pl ON pl.player_id = p.id
-       LEFT JOIN player_league_ratings plr ON plr.player_id = p.id AND plr.league_id = pl.league_id
-       WHERE pl.league_id = ? AND p.is_active = 1
-       ORDER BY p.is_regular DESC, p.name`,
+      p.*,
+      COALESCE(plr.position, p.position) as effective_position,
+      COALESCE(plr.forward_positions, p.forward_positions) as effective_forward_positions,
+      COALESCE(plr.offense_weight, p.offense_weight) as effective_offense_weight,
+      COALESCE(plr.defense_weight, p.defense_weight) as effective_defense_weight,
+      COALESCE(plr.defense_rating, p.defense_rating) as effective_defense_rating,
+      COALESCE(plr.forward_rating, p.forward_rating) as effective_forward_rating,
+      COALESCE(plr.goalie_rating, p.goalie_rating) as effective_goalie_rating
+      FROM players p
+      JOIN player_leagues pl ON pl.player_id = p.id
+      LEFT JOIN player_league_ratings plr ON plr.player_id = p.id AND plr.league_id = pl.league_id
+      WHERE pl.league_id = ? AND p.is_active = 1
+      ORDER BY p.is_regular DESC, p.name`,
       [req.leagueId]
     ) as (Player & {
       effective_position: string;
+      effective_forward_positions: string | null;
       effective_offense_weight: number;
       effective_defense_weight: number;
       effective_defense_rating: number;
@@ -65,15 +82,16 @@ router.get('/', authenticateToken, async (req: AuthRequest, res: Response) => {
     })[];
 
     // Transform the results to use effective ratings
-    const transformedPlayers = players.map(player => ({
-      ...player,
-      position: player.effective_position,
-      offense_weight: player.effective_offense_weight,
-      defense_weight: player.effective_defense_weight,
-      defense_rating: player.effective_defense_rating,
-      forward_rating: player.effective_forward_rating,
-      goalie_rating: player.effective_goalie_rating,
-    }));
+  const transformedPlayers = players.map(player => ({
+    ...player,
+    position: player.effective_position,
+    forward_positions: player.effective_forward_positions,
+    offense_weight: player.effective_offense_weight,
+    defense_weight: player.effective_defense_weight,
+    defense_rating: player.effective_defense_rating,
+    forward_rating: player.effective_forward_rating,
+    goalie_rating: player.effective_goalie_rating,
+  }));
 
     res.json(transformedPlayers);
   } catch (error) {
@@ -184,6 +202,7 @@ router.post('/', authenticateToken, requireAdmin, async (req: AuthRequest, res: 
       phone,
       is_regular,
       position,
+      forward_positions,
       offense_weight,
       defense_weight,
       defense_rating,
@@ -221,14 +240,17 @@ router.post('/', authenticateToken, requireAdmin, async (req: AuthRequest, res: 
       }
     }
 
+    const normalizedPosition = normalizePosition(position);
+
     const result = await runAsync(
       `INSERT INTO players
-      (league_id, name, position, email, phone, is_regular, offense_weight, defense_weight, defense_rating, forward_rating, goalie_rating)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      (league_id, name, position, forward_positions, email, phone, is_regular, offense_weight, defense_weight, defense_rating, forward_rating, goalie_rating)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         req.leagueId,
         name,
-        normalizePosition(position),
+        normalizedPosition,
+        normalizeForwardPositions(forward_positions, normalizedPosition),
         email || null,
         phone || null,
         is_regular ? 1 : 0,
@@ -267,6 +289,7 @@ router.put('/:id', authenticateToken, requireAdmin, async (req: AuthRequest, res
       is_regular,
       is_active,
       position,
+      forward_positions,
       offense_weight,
       defense_weight,
       defense_rating,
@@ -287,16 +310,18 @@ router.put('/:id', authenticateToken, requireAdmin, async (req: AuthRequest, res
       return res.status(404).json({ error: 'Player not found in this league' });
     }
 
+    const normalizedPosition = normalizePosition(position);
+
     if (updateScope === 'league') {
-      // Update or insert league-specific ratings
       await runAsync(
         `INSERT OR REPLACE INTO player_league_ratings
-         (player_id, league_id, position, offense_weight, defense_weight, defense_rating, forward_rating, goalie_rating, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+        (player_id, league_id, position, forward_positions, offense_weight, defense_weight, defense_rating, forward_rating, goalie_rating, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
         [
           playerId,
           req.leagueId,
-          normalizePosition(position),
+          normalizedPosition,
+          normalizeForwardPositions(forward_positions, normalizedPosition),
           normalizeWeight(offense_weight),
           normalizeWeight(defense_weight),
           normalizeRating(defense_rating),
@@ -305,14 +330,14 @@ router.put('/:id', authenticateToken, requireAdmin, async (req: AuthRequest, res
         ]
       );
     } else {
-      // Update global player data
       await runAsync(
         `UPDATE players
-        SET name = ?, position = ?, email = ?, phone = ?, is_regular = ?, is_active = ?, offense_weight = ?, defense_weight = ?, defense_rating = ?, forward_rating = ?, goalie_rating = ?
+        SET name = ?, position = ?, forward_positions = ?, email = ?, phone = ?, is_regular = ?, is_active = ?, offense_weight = ?, defense_weight = ?, defense_rating = ?, forward_rating = ?, goalie_rating = ?
         WHERE id = ?`,
         [
           name,
-          normalizePosition(position),
+          normalizedPosition,
+          normalizeForwardPositions(forward_positions, normalizedPosition),
           email || null,
           phone || null,
           is_regular ? 1 : 0,
@@ -334,21 +359,23 @@ router.put('/:id', authenticateToken, requireAdmin, async (req: AuthRequest, res
     }
 
     // Return the updated player data
-    const player = await getAsync(
+  const player = await getAsync(
       `SELECT 
-        p.*,
-        COALESCE(plr.position, p.position) as effective_position,
-        COALESCE(plr.offense_weight, p.offense_weight) as effective_offense_weight,
-        COALESCE(plr.defense_weight, p.defense_weight) as effective_defense_weight,
-        COALESCE(plr.defense_rating, p.defense_rating) as effective_defense_rating,
-        COALESCE(plr.forward_rating, p.forward_rating) as effective_forward_rating,
-        COALESCE(plr.goalie_rating, p.goalie_rating) as effective_goalie_rating
-       FROM players p
-       LEFT JOIN player_league_ratings plr ON plr.player_id = p.id AND plr.league_id = ?
-       WHERE p.id = ?`,
+      p.*,
+      COALESCE(plr.position, p.position) as effective_position,
+      COALESCE(plr.forward_positions, p.forward_positions) as effective_forward_positions,
+      COALESCE(plr.offense_weight, p.offense_weight) as effective_offense_weight,
+      COALESCE(plr.defense_weight, p.defense_weight) as effective_defense_weight,
+      COALESCE(plr.defense_rating, p.defense_rating) as effective_defense_rating,
+      COALESCE(plr.forward_rating, p.forward_rating) as effective_forward_rating,
+      COALESCE(plr.goalie_rating, p.goalie_rating) as effective_goalie_rating
+      FROM players p
+      LEFT JOIN player_league_ratings plr ON plr.player_id = p.id AND plr.league_id = ?
+      WHERE p.id = ?`,
       [req.leagueId, playerId]
     ) as (Player & {
       effective_position: string;
+      effective_forward_positions: string | null;
       effective_offense_weight: number;
       effective_defense_weight: number;
       effective_defense_rating: number;
@@ -361,15 +388,16 @@ router.put('/:id', authenticateToken, requireAdmin, async (req: AuthRequest, res
     }
 
     // Transform the result to use effective ratings
-    const transformedPlayer = {
-      ...player,
-      position: player.effective_position,
-      offense_weight: player.effective_offense_weight,
-      defense_weight: player.effective_defense_weight,
-      defense_rating: player.effective_defense_rating,
-      forward_rating: player.effective_forward_rating,
-      goalie_rating: player.effective_goalie_rating,
-    };
+  const transformedPlayer = {
+    ...player,
+    position: player.effective_position,
+    forward_positions: player.effective_forward_positions,
+    offense_weight: player.effective_offense_weight,
+    defense_weight: player.effective_defense_weight,
+    defense_rating: player.effective_defense_rating,
+    forward_rating: player.effective_forward_rating,
+    goalie_rating: player.effective_goalie_rating,
+  };
 
     res.json(transformedPlayer);
   } catch (error) {

--- a/server/src/routes/teams.ts
+++ b/server/src/routes/teams.ts
@@ -9,6 +9,7 @@ interface RatedPlayer {
   id: number;
   name: string;
   position: 'forward' | 'defense' | 'goalie';
+  forward_positions?: string;
   offense_weight: number;
   defense_weight: number;
   defense_rating: number;
@@ -248,12 +249,12 @@ router.post('/:gameId', authenticateToken, requireAdmin, async (req: AuthRequest
 
     // Get created teams
     const createdTeams = await allAsync(`
-      SELECT t.team_number, t.player_id, p.name as player_name, p.position, t.team_name
-      FROM teams t
-      JOIN players p ON t.player_id = p.id
-      JOIN player_leagues pl ON pl.player_id = p.id
-      WHERE t.${targetColumn} = ? AND pl.league_id = ?
-      ORDER BY t.team_number, p.name
+    SELECT t.team_number, t.player_id, p.name as player_name, p.position, p.forward_positions, t.team_name
+    FROM teams t
+    JOIN players p ON t.player_id = p.id
+    JOIN player_leagues pl ON pl.player_id = p.id
+    WHERE t.${targetColumn} = ? AND pl.league_id = ?
+    ORDER BY t.team_number, p.name
     `, [targetValue, req.leagueId]) as TeamWithPlayer[];
 
     res.json(createdTeams);
@@ -286,10 +287,10 @@ router.post('/:gameId/auto-balance', authenticateToken, requireAdmin, async (req
 
     // Build planning teams from active regulars, independent of attendance confirmations.
     const presentPlayers = await allAsync(`
-      SELECT p.id, p.name, p.position, p.offense_weight, p.defense_weight, p.defense_rating, p.forward_rating, p.goalie_rating
-      FROM players p
-      JOIN player_leagues pl ON pl.player_id = p.id
-      WHERE pl.league_id = ? AND p.is_active = 1 AND p.is_regular = 1
+    SELECT p.id, p.name, p.position, p.forward_positions, p.offense_weight, p.defense_weight, p.defense_rating, p.forward_rating, p.goalie_rating
+    FROM players p
+    JOIN player_leagues pl ON pl.player_id = p.id
+    WHERE pl.league_id = ? AND p.is_active = 1 AND p.is_regular = 1
     `, [req.leagueId]) as RatedPlayer[];
 
     if (presentPlayers.length < 2) {
@@ -432,12 +433,12 @@ router.post('/:gameId/auto-balance', authenticateToken, requireAdmin, async (req
 
     // Get created teams
     const createdTeams = await allAsync(`
-      SELECT t.team_number, t.player_id, p.name as player_name, p.position, t.team_name
-      FROM teams t
-      JOIN players p ON t.player_id = p.id
-      JOIN player_leagues pl ON pl.player_id = p.id
-      WHERE t.${targetColumn} = ? AND pl.league_id = ?
-      ORDER BY t.team_number, p.name
+    SELECT t.team_number, t.player_id, p.name as player_name, p.position, p.forward_positions, t.team_name
+    FROM teams t
+    JOIN players p ON t.player_id = p.id
+    JOIN player_leagues pl ON pl.player_id = p.id
+    WHERE t.${targetColumn} = ? AND pl.league_id = ?
+    ORDER BY t.team_number, p.name
     `, [targetValue, req.leagueId]) as TeamWithPlayer[];
 
     res.json(createdTeams);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -11,6 +11,8 @@ export interface LeagueAccess {
 
 export type PlayerPosition = 'forward' | 'defense' | 'goalie';
 
+export type ForwardPosition = 'center' | 'winger';
+
 export interface User {
   id: number;
   username: string;
@@ -26,6 +28,7 @@ export interface Player {
   user_id?: number;
   name: string;
   position: PlayerPosition;
+  forward_positions?: string;
   email?: string;
   phone?: string;
   is_regular: number;
@@ -96,6 +99,7 @@ export interface TeamWithPlayer {
   player_id: number;
   player_name: string;
   position: 'forward' | 'defense' | 'goalie';
+  forward_positions?: string;
   team_name?: string;
 }
 


### PR DESCRIPTION
Summary
- Add forward sub-positions (Center/Winger) to the player model, allowing forwards to be classified as Center-only, Winger-only, or both (C/W)
- Update team roster display to group forwards by sub-position (C, W, C/W) instead of a flat "F" group
- Add i18n support for Center, Winger, and C/W labels in both English and French
Changes
Database
- Added forward_positions TEXT column to players table (stores JSON array, e.g. ["center","winger"])
- Added forward_positions TEXT column to player_league_ratings table for league-specific overrides
- Added migrations for both columns; existing forwards default to ["center","winger"]
- Updated seed data to assign varied forward positions
Server
- Added ForwardPosition type ('center' | 'winger') and forward_positions field to Player and TeamWithPlayer interfaces
- Added normalizeForwardPositions() — validates/parses the array, defaults to both for forwards, null for non-forwards
- Updated all COALESCE queries in players.ts to include forward_positions from league overrides
- Updated create/update handlers to persist forward_positions
- Updated team and game queries to select p.forward_positions
Client
- Added forward_positions?: string to Player and Team types
- Players page: position column now shows Forward (C), Forward (W), or Forward (C/W); create/edit dialogs show Center and Winger checkboxes when position is Forward (at least one must remain checked)
- Game detail page: team rosters group forwards into C, W, and C/W sub-sections instead of a single F group
- Added i18n keys: players.center, players.winger, players.forwardPositions, players.centerWinger (EN + FR)